### PR TITLE
fixed client lookup

### DIFF
--- a/skel/runtest.sh
+++ b/skel/runtest.sh
@@ -77,8 +77,7 @@ parse() {
   rm -f "$file"
 }
 
-client="./${1%.*}"
-( Y2DIR=$Y2DIR:$Y2BASE_Y2DIR LD_LIBRARY_PATH=$Y2BASE_LD_LIBRARY_PATH $Y2BASE -l - -c "$logconf" $Y2BASEFLAGS $OPTIONS "$client" UI 2>&1 ) | parse >"$2" 2>"$3"
+( Y2DIR=$Y2DIR:$Y2BASE_Y2DIR LD_LIBRARY_PATH=$Y2BASE_LD_LIBRARY_PATH $Y2BASE -l - -c "$logconf" $Y2BASEFLAGS $OPTIONS "$1" UI 2>&1 ) | parse >"$2" 2>"$3"
 
 retcode="$PIPESTATUS"
 if [ "$retcode" -gt 0 ]; then


### PR DESCRIPTION
formerly client="./${1%.rb}" was necessary but %.\* was wrong. #2 breaks the builds.

I shall run tests before pushing
