### PR TITLE
skip files which do not have the corresponding stderr and stdout files

### DIFF
--- a/package/yast2-testsuite.changes
+++ b/package/yast2-testsuite.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 13 13:36:57 UTC 2013 - lslezak@suse.cz
+
+- skip files which do not have the corresponding stderr and stdout
+  files, these are likely just include files, not real tests
+
+-------------------------------------------------------------------
 Thu May 16 13:26:32 UTC 2013 - mvidner@suse.com
 
 - correctly pass the logging produced by Testsuite.rb (bnc#819137).

--- a/skel/unix.exp
+++ b/skel/unix.exp
@@ -53,6 +53,13 @@ proc testsuite-run { src } {
       set options "-I $sourcedir -M $sourcedir"
   }
 
+  # skip the file if there is no stderr and stdout file,
+  # it is likely just an include file which should not be executed
+  if {[expr ![file exists $stderr_name]] && [expr ![file exists $stdout_name]]} {
+      puts "Skipping file $fname ..."
+      return 0
+  }
+
   puts "Running $base_name ..."
 
   # run the test


### PR DESCRIPTION
these are likely just include files, not real tests
