### PR TITLE
skel: runtest.sh: Set Y2DIR to a sensible default value

### DIFF
--- a/skel/runtest.sh
+++ b/skel/runtest.sh
@@ -77,6 +77,12 @@ parse() {
   rm -f "$file"
 }
 
+# Set a good default value so the testsuite can use the local modules
+# instead of the system ones.
+if [ -z "${Y2DIR+x}" ] && [ -d ../src ]; then
+	Y2DIR="../src"
+fi
+
 ( Y2DIR=$Y2DIR:$Y2BASE_Y2DIR LD_LIBRARY_PATH=$Y2BASE_LD_LIBRARY_PATH $Y2BASE -l - -c "$logconf" $Y2BASEFLAGS $OPTIONS "$1" UI 2>&1 ) | tee "raw.$3" | parse >"$2" 2>"$3"
 
 retcode="$PIPESTATUS"


### PR DESCRIPTION
Set Y2DIR to '../src' in order to try and pick the local YaST2 modules
instead of using the system ones. This allows running testsuites against
the local tree without having to run 'make install' first.

I originally noticed this problem when I ran 'make check' in yast-yast2 and I noticed some failures. Then I realized that the testsuite was ran against the installed modules instead of the one in the local repository. I believe it would make sense for 'make check' to not require 'make install' or manually having to set Y2DIR before every test so I suggest to try and fix that in yast-testsuite.