### PR TITLE
Prevent failures with dejagnu-1.6 (bsc#979519)

### DIFF
--- a/package/yast2-testsuite.changes
+++ b/package/yast2-testsuite.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 17 15:52:40 UTC 2016 - mvidner@suse.com
+
+- Prevent failures with dejagnu-1.6 (bsc#979519).
+- 3.1.4
+
+-------------------------------------------------------------------
 Mon Mar  7 12:46:40 UTC 2016 - mvidner@suse.com
 
 - Default Y2DIR to ../src to enable 'make check'

--- a/package/yast2-testsuite.spec
+++ b/package/yast2-testsuite.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-testsuite
-Version:        3.1.3
+Version:        3.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/skel/testsuite.exp
+++ b/skel/testsuite.exp
@@ -15,7 +15,10 @@ if [catch {set pattern $CASE }] {
     set pattern "*"
 }
 
-set filenames [lsort [glob "$srcdir/tests/$pattern.{ycp,rb}"]]
+if [catch {set filenames [glob "$srcdir/tests/$pattern.{ycp,rb}"]}] {
+    puts "\nNo test cases found\n"
+    exit 0
+}
 
 puts "\nChecking started\n"
 


### PR DESCRIPTION
[bsc#979519](https://bugzilla.suse.com/show_bug.cgi?id=979519) " update of dejagnu breaks test of yast"

It is this change in 1.6:
  * The --status command line option is now the default. This means 
    that any error in the testsuite Tcl scripts will cause runtest 
    to abort with exit status code 2.  The --status option has been 
    removed from the documentation, but will continue to be 
    accepted for backward compatibility.

Our testsuite has for a long time output
```
  ERROR: no files matched glob pattern "./tests/*.{ycp,rb}"
```
for some tests but it got treated as harmless so we never got around to fix it. The time has come now.
